### PR TITLE
Fix: Sanitize HTTP_HOST in WSGI environ

### DIFF
--- a/app.py
+++ b/app.py
@@ -37,12 +37,23 @@ def chrome_devtools():
 
 
 @app.before_request
-def check_content_length():
+def before_request_funcs():
+    # Sanitize HTTP_HOST
+    original_host = request.environ.get('HTTP_HOST')
+    if original_host and ',' in original_host:
+        new_host = original_host.split(',', 1)[0]
+        request.environ['HTTP_HOST'] = new_host
+        current_app.logger.info(f"Sanitizing HTTP_HOST: Original '{original_host}', New: '{new_host}'")
+
+    # Check content length
     if request.method in ['POST', 'PUT', 'PATCH', 'DELETE']:
         if request.content_length is None and request.headers.get('Transfer-Encoding', '').lower() != 'chunked':
             current_app.logger.warning(
                 f"Request to {request.path} from {request.remote_addr} without Content-Length or chunked encoding."
             )
+            # It's unusual to 'pass' here. Typically, you might return an error response
+            # or allow processing to continue if this is not a critical check.
+            # For now, keeping original behavior.
             pass
 
 


### PR DESCRIPTION
The Werkzeug library can raise a ValueError when parsing the Host header if it contains unexpected characters, such as a comma-separated list of hosts/IPs often inserted by misconfigured proxies.

This change introduces a sanitization step in `app.before_request` to clean the `HTTP_HOST` value in the WSGI environment. If a comma is present in `HTTP_HOST`, the value is split, and only the first part is retained. This ensures that Werkzeug receives a parsable host, preventing the `ValueError: Port could not be cast to integer value` error.

Logging has been added to record when `HTTP_HOST` sanitization occurs, showing the original and the sanitized value for easier debugging and verification.